### PR TITLE
preserve source map location for added rules and declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,10 @@ module.exports = postcss.plugin("foft-classes", options => {
               };
 
               families.forEach(family => {
-                insert.stages.push({
+                insert.stages.push( decl.clone({
                   prop: "font-family",
                   value: family
-                });
+                }) );
               });
 
               insertions.push(insert);
@@ -55,7 +55,8 @@ module.exports = postcss.plugin("foft-classes", options => {
 
     function getRule(rule, className) {
       return postcss.rule({
-        selector: modifySelector( rule.selector, className )
+        selector: modifySelector( rule.selector, className ),
+        source: rule.source
       });
     }
 


### PR DESCRIPTION
This makes the source map output for this plugin's changes a little nicer. Without it, in dev tools you'll see that the added rules have `<no source>`:

<img width="293" alt="screen shot 2018-03-23 at 9 01 16 pm" src="https://user-images.githubusercontent.com/870668/37858621-a1cfc5dc-2edd-11e8-9fc6-c6321b7fbab6.png">

However, with this change, we get the correct original source of the `font-family` declaration:

<img width="300" alt="screen shot 2018-03-23 at 8 59 04 pm" src="https://user-images.githubusercontent.com/870668/37858631-bfba0c74-2edd-11e8-808b-e6d106f892b0.png">

The technique for preserving the source or cloning elements comes right out of the PostCSS API documentation: http://api.postcss.org/Node.html#source

Thanks for making this plugin!